### PR TITLE
Improves String Formatting

### DIFF
--- a/src/com/Jessy1237/DwarfCraft/Util.java
+++ b/src/com/Jessy1237/DwarfCraft/Util.java
@@ -334,7 +334,7 @@ public class Util {
 				return String.format("Unknown Dye(%d)", item.getData().getData());
 			}
 		default:
-			return item.getType().toString();
+			return cleanEnumString(item.getType().toString());
 		}
 	}
 
@@ -395,8 +395,21 @@ public class Util {
 		case OCELOT:
 			return "Ocelot";
 		default:
-			return mCreature.getName();
+			return cleanEnumString(mCreature.name().toString());
 		}
+	}
+	
+	public static String cleanEnumString(String enumStr) {
+		String enumString = enumStr.toLowerCase();
+		String[] enumWords = enumString.split("_");
+	    
+	    StringBuffer sb = new StringBuffer();
+	    for (String word : enumWords) {
+	        sb.append(word.substring(0, 1).toUpperCase() + word.substring(1));
+	        sb.append(" ");
+	    }
+		
+		return sb.toString().trim();
 	}
 
 	public enum FoodLevel {


### PR DESCRIPTION
Enum Strings are without a doubt pretty messy especially when printing
them to chat. This performs some string magic to try to make them look a
bit better. It removes the undercores and replaces them with spaces. Also
fixes the capitalization to be 'Title Case' capitalization where the first
letter of every word is capitalized. For example this turns "MAGMA_CREAM"
to "Magma Cream" and "BLAZE_ROD to "Blaze Rod".
